### PR TITLE
Fix Ogg Vorbis support by adding missing libraries to vorbisfile configure check

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -491,7 +491,7 @@ if test x$enable_music_ogg = xyes; then
         fi
     else
         AC_CHECK_HEADER([vorbis/vorbisfile.h], [have_ogg_hdr=yes])
-        AC_CHECK_LIB([vorbisfile], [ov_open_callbacks], [have_ogg_lib=yes])
+        AC_CHECK_LIB([vorbisfile], [ov_open_callbacks], [have_ogg_lib=yes], [], [-lvorbis -logg])
         if test x$have_ogg_hdr = xyes -a x$have_ogg_lib = xyes; then
             case "$host" in
                 *-*-darwin*)


### PR DESCRIPTION
Without this change, I get this when running `configure`:
<details><summary>config.log</summary>
<p>

```
configure:9537: checking for ov_open_callbacks in -lvorbisfile
configure:9562: psp-gcc -o conftest -g -O2 -G0 -I"/usr/local/pspdev/psp/sdk/include"   -DLIBMIKMOD_MUSIC -I/usr/local/pspdev/psp/include     -L/usr/local/pspdev/psp/sdk/lib -L/usr/local/pspdev/psp/lib -lc -lpspuser  conftest.c -lvorbisfile   -lc -lpspuser -L/usr/local/pspdev/psp/lib -lmikmod -lm >&5
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `_get_next_page':
vorbisfile.c:(.text+0x158): undefined reference to `ogg_sync_pageseek'
vorbisfile.c:(.text+0x18c): undefined reference to `ogg_sync_buffer'
vorbisfile.c:(.text+0x278): undefined reference to `ogg_sync_wrote'
vorbisfile.c:(.text+0x2a8): undefined reference to `ogg_sync_pageseek'
vorbisfile.c:(.text+0x2dc): undefined reference to `ogg_sync_buffer'
vorbisfile.c:(.text+0x308): undefined reference to `ogg_sync_wrote'
vorbisfile.c:(.text+0x314): undefined reference to `ogg_sync_pageseek'
vorbisfile.c:(.text+0x36c): undefined reference to `ogg_sync_pageseek'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `_fetch_headers':
vorbisfile.c:(.text+0x454): undefined reference to `ogg_page_serialno'
vorbisfile.c:(.text+0x464): undefined reference to `ogg_stream_reset_serialno'
vorbisfile.c:(.text+0x484): undefined reference to `vorbis_info_init'
vorbisfile.c:(.text+0x48c): undefined reference to `vorbis_comment_init'
vorbisfile.c:(.text+0x4a4): undefined reference to `ogg_stream_pagein'
vorbisfile.c:(.text+0x4b0): undefined reference to `ogg_stream_packetout'
vorbisfile.c:(.text+0x4d0): undefined reference to `vorbis_synthesis_headerin'
vorbisfile.c:(.text+0x520): undefined reference to `vorbis_info_clear'
vorbisfile.c:(.text+0x528): undefined reference to `vorbis_comment_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_clear.part.0':
vorbisfile.c:(.text+0x608): undefined reference to `vorbis_block_clear'
vorbisfile.c:(.text+0x610): undefined reference to `vorbis_dsp_clear'
vorbisfile.c:(.text+0x618): undefined reference to `ogg_stream_clear'
vorbisfile.c:(.text+0x688): undefined reference to `ogg_sync_clear'
vorbisfile.c:(.text+0x6d8): undefined reference to `vorbis_info_clear'
vorbisfile.c:(.text+0x6ec): undefined reference to `vorbis_comment_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `_get_next_page.constprop.0':
vorbisfile.c:(.text+0x740): undefined reference to `ogg_sync_pageseek'
vorbisfile.c:(.text+0x774): undefined reference to `ogg_sync_buffer'
vorbisfile.c:(.text+0x808): undefined reference to `ogg_sync_wrote'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `_fetch_and_process_packet.constprop.1':
vorbisfile.c:(.text+0xa78): undefined reference to `vorbis_synthesis_init'
vorbisfile.c:(.text+0xa8c): undefined reference to `vorbis_block_init'
vorbisfile.c:(.text+0xab0): undefined reference to `ogg_stream_pagein'
vorbisfile.c:(.text+0xad8): undefined reference to `vorbis_synthesis'
vorbisfile.c:(.text+0xaec): undefined reference to `ogg_stream_packetout'
vorbisfile.c:(.text+0xb30): undefined reference to `vorbis_synthesis_init'
vorbisfile.c:(.text+0xb48): undefined reference to `ogg_page_serialno'
vorbisfile.c:(.text+0xb88): undefined reference to `ogg_stream_reset_serialno'
vorbisfile.c:(.text+0xba0): undefined reference to `ogg_page_serialno'
vorbisfile.c:(.text+0xbfc): undefined reference to `ogg_stream_reset_serialno'
vorbisfile.c:(.text+0xc2c): undefined reference to `vorbis_synthesis_pcmout'
vorbisfile.c:(.text+0xc44): undefined reference to `vorbis_synthesis_blockin'
vorbisfile.c:(.text+0xc50): undefined reference to `vorbis_synthesis_pcmout'
vorbisfile.c:(.text+0xcfc): undefined reference to `vorbis_synthesis_pcmout'
vorbisfile.c:(.text+0xd74): undefined reference to `vorbis_synthesis_pcmout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `_ov_getlap.isra.0':
vorbisfile.c:(.text+0xe04): undefined reference to `vorbis_synthesis_pcmout'
vorbisfile.c:(.text+0xe70): undefined reference to `vorbis_synthesis_read'
vorbisfile.c:(.text+0xeb8): undefined reference to `vorbis_synthesis_lapout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `_ov_64_seek_lap':
vorbisfile.c:(.text+0x1088): undefined reference to `vorbis_synthesis_halfrate_p'
vorbisfile.c:(.text+0x10a0): undefined reference to `vorbis_info_blocksize'
vorbisfile.c:(.text+0x10b8): undefined reference to `vorbis_window'
vorbisfile.c:(.text+0x11b8): undefined reference to `vorbis_synthesis_pcmout'
vorbisfile.c:(.text+0x11f8): undefined reference to `vorbis_info_blocksize'
vorbisfile.c:(.text+0x1210): undefined reference to `vorbis_window'
vorbisfile.c:(.text+0x1220): undefined reference to `vorbis_synthesis_lapout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `_ov_d_seek_lap':
vorbisfile.c:(.text+0x1368): undefined reference to `vorbis_synthesis_halfrate_p'
vorbisfile.c:(.text+0x1380): undefined reference to `vorbis_info_blocksize'
vorbisfile.c:(.text+0x1398): undefined reference to `vorbis_window'
vorbisfile.c:(.text+0x1494): undefined reference to `vorbis_synthesis_pcmout'
vorbisfile.c:(.text+0x14d4): undefined reference to `vorbis_info_blocksize'
vorbisfile.c:(.text+0x14ec): undefined reference to `vorbis_window'
vorbisfile.c:(.text+0x14fc): undefined reference to `vorbis_synthesis_lapout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `_fetch_and_process_packet.constprop.0':
vorbisfile.c:(.text+0x15bc): undefined reference to `vorbis_synthesis_init'
vorbisfile.c:(.text+0x15d0): undefined reference to `vorbis_block_init'
vorbisfile.c:(.text+0x15f4): undefined reference to `ogg_stream_pagein'
vorbisfile.c:(.text+0x16c4): undefined reference to `vorbis_synthesis_init'
vorbisfile.c:(.text+0x1714): undefined reference to `vorbis_synthesis'
vorbisfile.c:(.text+0x1728): undefined reference to `ogg_stream_packetout'
vorbisfile.c:(.text+0x1770): undefined reference to `ogg_page_serialno'
vorbisfile.c:(.text+0x1780): undefined reference to `vorbis_dsp_clear'
vorbisfile.c:(.text+0x1788): undefined reference to `vorbis_block_clear'
vorbisfile.c:(.text+0x17a0): undefined reference to `ogg_page_serialno'
vorbisfile.c:(.text+0x17e0): undefined reference to `ogg_stream_reset_serialno'
vorbisfile.c:(.text+0x17f4): undefined reference to `vorbis_info_clear'
vorbisfile.c:(.text+0x17fc): undefined reference to `vorbis_comment_clear'
vorbisfile.c:(.text+0x1828): undefined reference to `ogg_stream_reset_serialno'
vorbisfile.c:(.text+0x1858): undefined reference to `vorbis_synthesis_pcmout'
vorbisfile.c:(.text+0x1870): undefined reference to `vorbis_synthesis_blockin'
vorbisfile.c:(.text+0x187c): undefined reference to `vorbis_synthesis_pcmout'
vorbisfile.c:(.text+0x1928): undefined reference to `vorbis_synthesis_pcmout'
vorbisfile.c:(.text+0x19a8): undefined reference to `vorbis_synthesis_pcmout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `_bisect_forward_serialno':
vorbisfile.c:(.text+0x1ab0): undefined reference to `ogg_sync_reset'
vorbisfile.c:(.text+0x1b34): undefined reference to `ogg_sync_reset'
vorbisfile.c:(.text+0x1c08): undefined reference to `ogg_page_serialno'
vorbisfile.c:(.text+0x1cc8): undefined reference to `ogg_page_serialno'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `_get_prev_page':
vorbisfile.c:(.text+0x1ddc): undefined reference to `ogg_sync_reset'
vorbisfile.c:(.text+0x1e7c): undefined reference to `ogg_sync_reset'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x1f74): undefined reference to `ogg_stream_reset_serialno'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x1f7c): undefined reference to `vorbis_synthesis_restart'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x1fa8): undefined reference to `ogg_sync_reset'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x1fb8): undefined reference to `ogg_stream_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x1fc0): undefined reference to `ogg_stream_reset'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x2010): undefined reference to `ogg_page_serialno'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x2050): undefined reference to `ogg_stream_reset_serialno'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x205c): undefined reference to `ogg_stream_reset_serialno'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x206c): undefined reference to `ogg_stream_pagein'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x2078): undefined reference to `ogg_stream_pagein'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x2080): undefined reference to `ogg_page_eos'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x209c): undefined reference to `ogg_stream_packetout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x20c8): undefined reference to `vorbis_packet_blocksize'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x2184): undefined reference to `ogg_stream_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x21d0): undefined reference to `ogg_page_serialno'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x21e0): undefined reference to `vorbis_dsp_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x21e8): undefined reference to `vorbis_block_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x21f4): undefined reference to `ogg_stream_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x2224): undefined reference to `ogg_stream_packetout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x224c): undefined reference to `ogg_stream_packetout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x227c): undefined reference to `ogg_stream_packetout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x2308): undefined reference to `ogg_stream_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x2310): undefined reference to `vorbis_dsp_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_raw_seek':
(.text+0x2318): undefined reference to `vorbis_block_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `_open_seekable2':
vorbisfile.c:(.text+0x2410): undefined reference to `ogg_page_serialno'
vorbisfile.c:(.text+0x24f0): undefined reference to `ogg_sync_reset'
vorbisfile.c:(.text+0x2550): undefined reference to `ogg_sync_reset'
vorbisfile.c:(.text+0x2560): undefined reference to `ogg_page_granulepos'
vorbisfile.c:(.text+0x25a0): undefined reference to `vorbis_info_clear'
vorbisfile.c:(.text+0x25ac): undefined reference to `vorbis_comment_clear'
vorbisfile.c:(.text+0x2650): undefined reference to `ogg_stream_reset_serialno'
vorbisfile.c:(.text+0x2674): undefined reference to `ogg_page_serialno'
vorbisfile.c:(.text+0x2694): undefined reference to `ogg_stream_pagein'
vorbisfile.c:(.text+0x26b0): undefined reference to `ogg_stream_packetout'
vorbisfile.c:(.text+0x26c0): undefined reference to `ogg_page_granulepos'
vorbisfile.c:(.text+0x26d8): undefined reference to `ogg_page_granulepos'
vorbisfile.c:(.text+0x2760): undefined reference to `ogg_sync_reset'
vorbisfile.c:(.text+0x27a8): undefined reference to `ogg_page_granulepos'
vorbisfile.c:(.text+0x27e4): undefined reference to `vorbis_packet_blocksize'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2aa4): undefined reference to `ogg_sync_reset'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2b70): undefined reference to `ogg_sync_reset'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2bc0): undefined reference to `ogg_sync_reset'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2bfc): undefined reference to `vorbis_dsp_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2c04): undefined reference to `vorbis_block_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2c18): undefined reference to `ogg_page_serialno'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2c34): undefined reference to `ogg_stream_reset_serialno'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2c40): undefined reference to `ogg_stream_pagein'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2c68): undefined reference to `ogg_stream_packetout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2c74): undefined reference to `ogg_stream_packetpeek'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2cb4): undefined reference to `ogg_sync_reset'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2cc4): undefined reference to `ogg_page_continued'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2cf8): undefined reference to `ogg_page_granulepos'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2d30): undefined reference to `ogg_page_granulepos'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2e58): undefined reference to `ogg_sync_reset'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2f80): undefined reference to `vorbis_dsp_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x2f88): undefined reference to `vorbis_block_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek_page':
(.text+0x31a8): undefined reference to `vorbis_synthesis_restart'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x3268): undefined reference to `vorbis_synthesis_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x3278): undefined reference to `vorbis_block_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x32ac): undefined reference to `ogg_stream_packetpeek'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x32e4): undefined reference to `ogg_page_serialno'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x32f4): undefined reference to `vorbis_dsp_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x32fc): undefined reference to `vorbis_block_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x330c): undefined reference to `ogg_page_serialno'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x334c): undefined reference to `ogg_stream_reset_serialno'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x3374): undefined reference to `vorbis_synthesis_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x3388): undefined reference to `vorbis_block_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x33b0): undefined reference to `ogg_stream_pagein'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x33bc): undefined reference to `ogg_stream_packetpeek'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x33dc): undefined reference to `vorbis_packet_blocksize'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x3428): undefined reference to `vorbis_info_blocksize'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x345c): undefined reference to `ogg_stream_packetout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x3468): undefined reference to `vorbis_synthesis_trackonly'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x3474): undefined reference to `vorbis_synthesis_blockin'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x3550): undefined reference to `ogg_stream_reset_serialno'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x356c): undefined reference to `vorbis_synthesis_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x3588): undefined reference to `ogg_stream_packetout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x35fc): undefined reference to `vorbis_synthesis_pcmout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x362c): undefined reference to `vorbis_synthesis_read'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x36a0): undefined reference to `vorbis_synthesis_read'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_pcm_seek':
(.text+0x370c): undefined reference to `vorbis_synthesis_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_open_callbacks':
(.text+0x386c): undefined reference to `ogg_sync_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_open_callbacks':
(.text+0x3880): undefined reference to `ogg_sync_buffer'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_open_callbacks':
(.text+0x389c): undefined reference to `ogg_sync_wrote'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_open_callbacks':
(.text+0x38e4): undefined reference to `ogg_stream_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_open_callbacks':
(.text+0x3978): undefined reference to `ogg_sync_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_open':
(.text+0x3a80): undefined reference to `ogg_sync_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_open':
(.text+0x3a94): undefined reference to `ogg_sync_buffer'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_open':
(.text+0x3ab0): undefined reference to `ogg_sync_wrote'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_open':
(.text+0x3af4): undefined reference to `ogg_stream_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_open':
(.text+0x3ba0): undefined reference to `ogg_sync_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_halfrate':
(.text+0x3c6c): undefined reference to `vorbis_synthesis_halfrate'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_halfrate':
(.text+0x3cbc): undefined reference to `vorbis_dsp_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_halfrate':
(.text+0x3cc4): undefined reference to `vorbis_block_clear'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_halfrate_p':
(.text+0x3cf4): undefined reference to `vorbis_synthesis_halfrate_p'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_test_callbacks':
(.text+0x3d90): undefined reference to `ogg_sync_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_test_callbacks':
(.text+0x3da4): undefined reference to `ogg_sync_buffer'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_test_callbacks':
(.text+0x3dc0): undefined reference to `ogg_sync_wrote'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_test_callbacks':
(.text+0x3e08): undefined reference to `ogg_stream_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_test_callbacks':
(.text+0x3e80): undefined reference to `ogg_sync_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_test':
(.text+0x3f70): undefined reference to `ogg_sync_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_test':
(.text+0x3f84): undefined reference to `ogg_sync_buffer'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_test':
(.text+0x3fa0): undefined reference to `ogg_sync_wrote'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_test':
(.text+0x3fe4): undefined reference to `ogg_stream_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_test':
(.text+0x4070): undefined reference to `ogg_sync_init'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_read':
(.text+0x54bc): undefined reference to `vorbis_synthesis_pcmout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_read':
(.text+0x55c0): undefined reference to `vorbis_synthesis_read'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_read_float':
(.text+0x5ac0): undefined reference to `vorbis_synthesis_pcmout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_read_float':
(.text+0x5ae4): undefined reference to `vorbis_synthesis_read'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_crosslap':
(.text+0x5c78): undefined reference to `vorbis_synthesis_pcmout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_crosslap':
(.text+0x5ce4): undefined reference to `vorbis_synthesis_halfrate_p'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_crosslap':
(.text+0x5cfc): undefined reference to `vorbis_synthesis_halfrate_p'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_crosslap':
(.text+0x5d2c): undefined reference to `vorbis_info_blocksize'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_crosslap':
(.text+0x5d3c): undefined reference to `vorbis_info_blocksize'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_crosslap':
(.text+0x5d50): undefined reference to `vorbis_window'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_crosslap':
(.text+0x5d60): undefined reference to `vorbis_window'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_crosslap':
(.text+0x5dc8): undefined reference to `vorbis_synthesis_lapout'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_crosslap':
(.text+0x5df8): undefined reference to `_analysis_output_always'
/usr/local/pspdev/psp/lib/libvorbisfile.a(vorbisfile.o): In function `ov_crosslap':
(.text+0x5e24): undefined reference to `_analysis_output_always'
collect2: error: ld returned 1 exit status
configure:9562: $? = 1
configure: failed program was:
| /* confdefs.h */
| #define PACKAGE_NAME ""
| #define PACKAGE_TARNAME ""
| #define PACKAGE_VERSION ""
| #define PACKAGE_STRING ""
| #define PACKAGE_BUGREPORT ""
| #define PACKAGE_URL ""
| #define STDC_HEADERS 1
| #define HAVE_SYS_TYPES_H 1
| #define HAVE_SYS_STAT_H 1
| #define HAVE_STDLIB_H 1
| #define HAVE_STRING_H 1
| #define HAVE_MEMORY_H 1
| #define HAVE_STRINGS_H 1
| #define HAVE_INTTYPES_H 1
| #define HAVE_STDINT_H 1
| #define HAVE_UNISTD_H 1
| #define LT_OBJDIR ".libs/"
| /* end confdefs.h.  */
| 
| /* Override any GCC internal prototype to avoid an error.
|    Use char because int might match the return type of a GCC
|    builtin and then its argument prototype would still apply.  */
| #ifdef __cplusplus
| extern "C"
| #endif
| char ov_open_callbacks ();
| int
| main ()
| {
| return ov_open_callbacks ();
|   ;
|   return 0;
| }
configure:9571: result: no
configure:9601: WARNING: *** Unable to find Ogg Vorbis library (http://www.xiph.org/)
configure:9603: WARNING: Ogg Vorbis support disabled
```
</p>
</details>

But with this change, everything works:
```
configure:9537: checking for ov_open_callbacks in -lvorbisfile
configure:9562: psp-gcc -o conftest -g -O2 -G0 -I"/usr/local/pspdev/psp/sdk/include"   -DLIBMIKMOD_MUSIC -I/usr/local/pspdev/psp/include     -L/usr/local/pspdev/psp/sdk/lib -L/usr/local/pspdev/psp/lib -lc -lpspuser  conftest.c -lvorbisfile -lvorbis -logg  -lc -lpspuser -L/usr/local/pspdev/psp/lib -lmikmod -lm >&5
configure:9562: $? = 0
configure:9571: result: yes
```